### PR TITLE
Remove dependency on oslo.utils (replace with small util code)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,8 @@
   - Allow the sleep function to be provided (so that
     various alternatives other than time.sleep can
     be used), ie eventlet.sleep (or other).
+  - Remove dependency on oslo.utils (replace with
+    small utility code that achieves the same effect).
 0.5:
   - Make it possible to provide a acquisition timeout
     to the interprocess lock (which when acquisition

--- a/fasteners/_utils.py
+++ b/fasteners/_utils.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2015 Yahoo! Inc. All Rights Reserved.
+#
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+try:
+    from time import monotonic as now
+except ImportError:
+    from time import time as now
+
+
+class StopWatch(object):
+    """A really basic stop watch."""
+
+    def __init__(self, duration=None):
+        self.duration = duration
+        self.started_at = None
+        self.stopped_at = None
+
+    def elapsed(self):
+        if self.stopped_at is not None:
+            t = self.stopped_at
+        else:
+            t = now()
+        return t - self.started_at
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        self.stopped_at = now()
+
+    def start(self):
+        self.started_at = now()
+        self.stopped_at = None
+
+    def expired(self):
+        if self.duration is None:
+            return False
+        else:
+            e = self.elapsed()
+            if e > self.duration:
+                return True
+            return False

--- a/fasteners/_utils.py
+++ b/fasteners/_utils.py
@@ -36,7 +36,8 @@ class StopWatch(object):
             t = self.stopped_at
         else:
             t = now()
-        return t - self.started_at
+        e = t - self.started_at
+        return max(0.0, e)
 
     def __enter__(self):
         self.start()

--- a/fasteners/lock.py
+++ b/fasteners/lock.py
@@ -21,12 +21,16 @@ import collections
 import contextlib
 import threading
 
-from oslo_utils import importutils
 import six
 
-# Used for the reader-writer lock get the right thread 'hack' (needed below).
-eventlet = importutils.try_import('eventlet')
-eventlet_patcher = importutils.try_import('eventlet.patcher')
+try:
+    # Used for the reader-writer lock get the right
+    # thread 'hack' (needed below).
+    import eventlet
+    from eventlet import patcher as eventlet_patcher
+except ImportError:
+    eventlet = None
+    eventlet_patcher = None
 
 
 def read_locked(*args, **kwargs):

--- a/fasteners/process_lock.py
+++ b/fasteners/process_lock.py
@@ -23,8 +23,9 @@ import os
 import threading
 import time
 
-from oslo_utils import timeutils
 import six
+
+from fasteners import _utils
 
 LOG = logging.getLogger(__name__)
 
@@ -144,7 +145,7 @@ class _InterProcessLock(object):
         if delay >= max_delay:
             max_delay = delay
         self._do_open()
-        watch = timeutils.StopWatch(duration=timeout)
+        watch = _utils.StopWatch(duration=timeout)
         if blocking:
             delay_func = functools.partial(self._backoff_multiplier_delay,
                                            delay=delay, max_delay=max_delay)

--- a/fasteners/tests/test_lock.py
+++ b/fasteners/tests/test_lock.py
@@ -25,10 +25,11 @@ except ImportError:
     from time import time as now
 
 from concurrent import futures
-from oslo_utils import timeutils
 
 import fasteners
 from fasteners import test
+
+from fasteners import _utils
 
 
 # NOTE(harlowja): Sleep a little so now() can not be the same (which will
@@ -108,7 +109,7 @@ class ReadWriteLockTest(test.TestCase):
 
     def test_no_double_writers(self):
         lock = fasteners.ReaderWriterLock()
-        watch = timeutils.StopWatch(duration=5)
+        watch = _utils.StopWatch(duration=5)
         watch.start()
         dups = collections.deque()
         active = collections.deque()
@@ -143,7 +144,7 @@ class ReadWriteLockTest(test.TestCase):
 
     def test_no_concurrent_readers_writers(self):
         lock = fasteners.ReaderWriterLock()
-        watch = timeutils.StopWatch(duration=5)
+        watch = _utils.StopWatch(duration=5)
         watch.start()
         dups = collections.deque()
         active = collections.deque()

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ with open("README.rst", "r") as readme:
     long_description = readme.read()
 
 install_requires = [
-    'oslo.utils>=1.4.0',
     'six',
 ]
 


### PR DESCRIPTION
Since this is meant to be a leaf dependency for openstack it should
not depend on any other openstack packages, so to make this happen
just have a really tiny ``_utils.py`` code module that contains the needed
functionality used from ``oslo.utils`` (at a later date we may be able
to better handle this).