### PR TITLE
Add more helpers + moar tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,8 @@
 0.7:
+  - Add helpful `locked` decorator that can
+    lock a method using a found attribute (a lock
+    object or list of lock objects) in the
+    instance the method is attached to.
 0.6:
   - Allow the sleep function to be provided (so that
     various alternatives other than time.sleep can

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@
     lock a method using a found attribute (a lock
     object or list of lock objects) in the
     instance the method is attached to.
+  - Expose top level `try_lock` function.
 0.6:
   - Allow the sleep function to be provided (so that
     various alternatives other than time.sleep can

--- a/fasteners/__init__.py
+++ b/fasteners/__init__.py
@@ -22,6 +22,7 @@ from __future__ import absolute_import
 
 from fasteners.lock import locked  # noqa
 from fasteners.lock import read_locked  # noqa
+from fasteners.lock import try_lock  # noqa
 from fasteners.lock import write_locked  # noqa
 
 from fasteners.lock import ReaderWriterLock  # noqa

--- a/fasteners/__init__.py
+++ b/fasteners/__init__.py
@@ -20,6 +20,7 @@
 
 from __future__ import absolute_import
 
+from fasteners.lock import locked  # noqa
 from fasteners.lock import read_locked  # noqa
 from fasteners.lock import write_locked  # noqa
 

--- a/fasteners/_utils.py
+++ b/fasteners/_utils.py
@@ -40,7 +40,8 @@ class LockStack(object):
 
     def acquire_lock(self, lock):
         gotten = lock.acquire()
-        self._stack.append(lock)
+        if gotten:
+            self._stack.append(lock)
         return gotten
 
     def __enter__(self):

--- a/fasteners/_utils.py
+++ b/fasteners/_utils.py
@@ -23,6 +23,30 @@ except ImportError:
     from time import time as now
 
 
+class LockStack(object):
+    """Simple lock stack to get and release many locks."""
+
+    def __init__(self):
+        self._stack = []
+
+    def acquire_lock(self, lock):
+        gotten = lock.acquire()
+        self._stack.append(lock)
+        return gotten
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        while self._stack:
+            lock = self._stack.pop()
+            try:
+                lock.release()
+            except Exception:
+                # Always suppress this exception...
+                pass
+
+
 class StopWatch(object):
     """A really basic stop watch."""
 

--- a/fasteners/_utils.py
+++ b/fasteners/_utils.py
@@ -24,7 +24,12 @@ except ImportError:
 
 
 class LockStack(object):
-    """Simple lock stack to get and release many locks."""
+    """Simple lock stack to get and release many locks.
+
+    An instance of this should **not** be used by many threads at the
+    same time, as the stack that is maintained will be corrupted and
+    invalid if that is attempted.
+    """
 
     def __init__(self):
         self._stack = []

--- a/fasteners/lock.py
+++ b/fasteners/lock.py
@@ -17,11 +17,18 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+try:
+    from contextlib import ExitStack  # noqa
+except ImportError:
+    from contextlib2 import ExitStack  # noqa
+
 import collections
 import contextlib
 import threading
 
 import six
+
+from fasteners import _utils
 
 try:
     # Used for the reader-writer lock get the right
@@ -228,3 +235,63 @@ class ReaderWriterLock(object):
                 with self._cond:
                     self._writer = None
                     self._cond.notify_all()
+
+
+@contextlib.contextmanager
+def try_lock(lock):
+    """Attempts to acquire a lock, and auto releases if acquired (on exit)."""
+    # NOTE(harlowja): the keyword argument for 'blocking' does not work
+    # in py2.x and only is fixed in py3.x (this adjustment is documented
+    # and/or debated in http://bugs.python.org/issue10789); so we'll just
+    # stick to the format that works in both (oddly the keyword argument
+    # works in py2.x but only with reentrant locks).
+    was_locked = lock.acquire(False)
+    try:
+        yield was_locked
+    finally:
+        if was_locked:
+            lock.release()
+
+
+def locked(*args, **kwargs):
+    """A locking **method** decorator.
+
+    It will look for a provided attribute (typically a lock or a list
+    of locks) on the first argument of the function decorated (typically this
+    is the 'self' object) and before executing the decorated function it
+    activates the given lock or list of locks as a context manager,
+    automatically releasing that lock on exit.
+
+    NOTE(harlowja): if no attribute name is provided then by default the
+    attribute named '_lock' is looked for (this attribute is expected to be
+    the lock/list of locks object/s) in the instance object this decorator
+    is attached to.
+    """
+
+    def decorator(f):
+        attr_name = kwargs.get('lock', '_lock')
+
+        @six.wraps(f)
+        def wrapper(self, *args, **kwargs):
+            attr_value = getattr(self, attr_name)
+            if isinstance(attr_value, (tuple, list)):
+                with ExitStack() as stack:
+                    for lock in attr_value:
+                        stack.enter_context(lock)
+                    return f(self, *args, **kwargs)
+            else:
+                lock = attr_value
+                with lock:
+                    return f(self, *args, **kwargs)
+
+        return wrapper
+
+    # This is needed to handle when the decorator has args or the decorator
+    # doesn't have args, python is rather weird here...
+    if kwargs or not args:
+        return decorator
+    else:
+        if len(args) == 1:
+            return decorator(args[0])
+        else:
+            return decorator

--- a/fasteners/lock.py
+++ b/fasteners/lock.py
@@ -28,8 +28,6 @@ import threading
 
 import six
 
-from fasteners import _utils
-
 try:
     # Used for the reader-writer lock get the right
     # thread 'hack' (needed below).

--- a/fasteners/lock.py
+++ b/fasteners/lock.py
@@ -17,14 +17,11 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-try:
-    from contextlib import ExitStack  # noqa
-except ImportError:
-    from contextlib2 import ExitStack  # noqa
-
 import collections
 import contextlib
 import threading
+
+from fasteners import _utils
 
 import six
 
@@ -273,9 +270,9 @@ def locked(*args, **kwargs):
         def wrapper(self, *args, **kwargs):
             attr_value = getattr(self, attr_name)
             if isinstance(attr_value, (tuple, list)):
-                with ExitStack() as stack:
+                with _utils.LockStack() as stack:
                     for lock in attr_value:
-                        stack.enter_context(lock)
+                        stack.acquire_lock(lock)
                     return f(self, *args, **kwargs)
             else:
                 lock = attr_value

--- a/fasteners/lock.py
+++ b/fasteners/lock.py
@@ -271,8 +271,10 @@ def locked(*args, **kwargs):
             attr_value = getattr(self, attr_name)
             if isinstance(attr_value, (tuple, list)):
                 with _utils.LockStack() as stack:
-                    for lock in attr_value:
-                        stack.acquire_lock(lock)
+                    for i, lock in enumerate(attr_value):
+                        if not stack.acquire_lock(lock):
+                            raise threading.ThreadError("Unable to acquire"
+                                                        " lock %s" % (i + 1))
                     return f(self, *args, **kwargs)
             else:
                 lock = attr_value

--- a/fasteners/tests/test_decorators.py
+++ b/fasteners/tests/test_decorators.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+
+#    Copyright (C) 2015 Yahoo! Inc. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import threading
+
+import fasteners
+from fasteners import test
+
+
+class Locked(object):
+    def __init__(self):
+        self._lock = threading.Lock()
+
+    @fasteners.locked
+    def i_am_locked(self, cb):
+        cb(self._lock.locked())
+
+    def i_am_not_locked(self, cb):
+        cb(self._lock.locked())
+
+
+class RWLocked(object):
+    def __init__(self):
+        self._lock = fasteners.ReaderWriterLock()
+
+    @fasteners.read_locked
+    def i_am_read_locked(self, cb):
+        cb(self._lock.owner)
+
+    @fasteners.write_locked
+    def i_am_write_locked(self, cb):
+        cb(self._lock.owner)
+
+    def i_am_not_locked(self, cb):
+        cb(self._lock.owner)
+
+
+class DecoratorsTest(test.TestCase):
+    def test_locked(self):
+        obj = Locked()
+        obj.i_am_locked(lambda is_locked: self.assertTrue(is_locked))
+        obj.i_am_not_locked(lambda is_locked: self.assertFalse(is_locked))
+
+    def test_read_write_locked(self):
+        reader = fasteners.ReaderWriterLock.READER
+        writer = fasteners.ReaderWriterLock.WRITER
+        obj = RWLocked()
+        obj.i_am_write_locked(lambda owner: self.assertEqual(owner, writer))
+        obj.i_am_read_locked(lambda owner: self.assertEqual(owner, reader))
+        obj.i_am_not_locked(lambda owner: self.assertIsNone(owner))

--- a/fasteners/tests/test_helpers.py
+++ b/fasteners/tests/test_helpers.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+#    Copyright (C) 2015 Yahoo! Inc. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import threading
+
+import fasteners
+from fasteners import test
+
+
+class HelpersTest(test.TestCase):
+    def test_try_lock(self):
+        lock = threading.Lock()
+        with fasteners.try_lock(lock) as locked:
+            self.assertTrue(locked)
+            with fasteners.try_lock(lock) as locked:
+                self.assertFalse(locked)

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,9 @@ with open("README.rst", "r") as readme:
 
 install_requires = [
     'six',
+    # Only needed for <= python 3.3, replace me with requirement
+    # markers in the future...
+    'contextlib2',
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,6 @@ with open("README.rst", "r") as readme:
 
 install_requires = [
     'six',
-    # Only needed for <= python 3.3, replace me with requirement
-    # markers in the future...
-    'contextlib2',
 ]
 
 setup(


### PR DESCRIPTION
Add a `locked` decorator and `try_lock` helper.
    
- This `locked` decorator is useful to lock a instance method
  where that instance object that the method is attached
  to has a lock object connected to an attribute (or list of
  locks) that should be acquired before/after running the
  decorated method.

Also adds more tests!