### PR TITLE
Add LICENSE in generated source tarballs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
Most distributions require shipping license in source tarballs.