### PR TITLE
Fix _ensure_tree on FreeBSD

### DIFF
--- a/fasteners/process_lock.py
+++ b/fasteners/process_lock.py
@@ -41,6 +41,8 @@ def _ensure_tree(path):
                 raise
             else:
                 return False
+        elif e.errno == errno.EISDIR:
+            return False
         else:
             raise
     else:


### PR DESCRIPTION
On FreeBSD os.makedirs sets errno to EISDIR instead of EEXiSTS
when a directory exists already, so handle this case instead of
raising and excpetion.