### PR TITLE
Canonicalize paths before using them further

### DIFF
--- a/fasteners/process_lock.py
+++ b/fasteners/process_lock.py
@@ -84,7 +84,7 @@ class _InterProcessLock(object):
 
     def __init__(self, path, sleep_func=time.sleep, logger=None):
         self.lockfile = None
-        self.path = path
+        self.path = _utils.canonicalize_path(path)
         self.acquired = False
         self.sleep_func = sleep_func
         self.logger = _utils.pick_first_not_none(logger, LOG)


### PR DESCRIPTION
Check and validate path types before further usage
and translate pathlib objects so that they can be
used correctly in further interprocess locking code.

Fixes issue #16