### PR TITLE
Add sanity __enter__ acquire check

### DIFF
--- a/fasteners/process_lock.py
+++ b/fasteners/process_lock.py
@@ -176,7 +176,12 @@ class _InterProcessLock(object):
             self.lockfile = None
 
     def __enter__(self):
-        self.acquire()
+        gotten = self.acquire()
+        if not gotten:
+            # This shouldn't happen, but just incase...
+            raise threading.ThreadError("Unable to acquire a file lock"
+                                        " on `%s` (when used as a"
+                                        " context manager)" % self.path)
         return self
 
     def release(self):


### PR DESCRIPTION
Just incase ``__enter__`` can (but should not) ever fail
at getting a lock raise a threading error if it ever
somehow does fail to get the lock.