### PR TITLE
Fix process_lock and tests on Win32

### DIFF
--- a/fasteners/process_lock.py
+++ b/fasteners/process_lock.py
@@ -223,21 +223,23 @@ class _InterProcessLock(object):
 class _WindowsLock(_InterProcessLock):
     """Interprocess lock implementation that works on windows systems."""
 
-    def trylock(self):
-        msvcrt.locking(self.lockfile.fileno(), msvcrt.LK_NBLCK, 1)
+    def trylock(self, lockfile=None):
+        fileno = (lockfile or self.lockfile).fileno()
+        msvcrt.locking(fileno, msvcrt.LK_NBLCK, 1)
 
-    def unlock(self):
-        msvcrt.locking(self.lockfile.fileno(), msvcrt.LK_UNLCK, 1)
+    def unlock(self, lockfile=None):
+        fileno = (lockfile or self.lockfile).fileno()
+        msvcrt.locking(fileno, msvcrt.LK_UNLCK, 1)
 
 
 class _FcntlLock(_InterProcessLock):
     """Interprocess lock implementation that works on posix systems."""
 
-    def trylock(self):
-        fcntl.lockf(self.lockfile, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    def trylock(self, lockfile=None):
+        fcntl.lockf(lockfile or self.lockfile, fcntl.LOCK_EX | fcntl.LOCK_NB)
 
-    def unlock(self):
-        fcntl.lockf(self.lockfile, fcntl.LOCK_UN)
+    def unlock(self, lockfile=None):
+        fcntl.lockf(lockfile or self.lockfile, fcntl.LOCK_UN)
 
 
 if os.name == 'nt':

--- a/fasteners/process_lock.py
+++ b/fasteners/process_lock.py
@@ -214,32 +214,44 @@ class _InterProcessLock(object):
         return os.path.exists(self.path)
 
     def trylock(self):
-        raise NotImplementedError()
+        self._trylock(self.lockfile)
 
     def unlock(self):
+        self._unlock(self.lockfile)
+
+    @staticmethod
+    def _trylock():
+        raise NotImplementedError()
+
+    @staticmethod
+    def _unlock():
         raise NotImplementedError()
 
 
 class _WindowsLock(_InterProcessLock):
     """Interprocess lock implementation that works on windows systems."""
 
-    def trylock(self, lockfile=None):
-        fileno = (lockfile or self.lockfile).fileno()
+    @staticmethod
+    def _trylock(lockfile):
+        fileno = lockfile.fileno()
         msvcrt.locking(fileno, msvcrt.LK_NBLCK, 1)
 
-    def unlock(self, lockfile=None):
-        fileno = (lockfile or self.lockfile).fileno()
+    @staticmethod
+    def _unlock(lockfile):
+        fileno = lockfile.fileno()
         msvcrt.locking(fileno, msvcrt.LK_UNLCK, 1)
 
 
 class _FcntlLock(_InterProcessLock):
     """Interprocess lock implementation that works on posix systems."""
 
-    def trylock(self, lockfile=None):
-        fcntl.lockf(lockfile or self.lockfile, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    @staticmethod
+    def _trylock(lockfile):
+        fcntl.lockf(lockfile, fcntl.LOCK_EX | fcntl.LOCK_NB)
 
-    def unlock(self, lockfile=None):
-        fcntl.lockf(lockfile or self.lockfile, fcntl.LOCK_UN)
+    @staticmethod
+    def _unlock(lockfile):
+        fcntl.lockf(lockfile, fcntl.LOCK_UN)
 
 
 if os.name == 'nt':

--- a/fasteners/tests/test_process_lock.py
+++ b/fasteners/tests/test_process_lock.py
@@ -250,6 +250,7 @@ class ProcessLockTest(test.TestCase):
 
             child_pipe.send(None)
 
+    @test.testtools.skipIf(WIN32, "Windows cannot open file handles twice")
     def test_non_destructive(self):
         lock_file = os.path.join(self.lock_dir, 'not-destroyed')
         with open(lock_file, 'w') as f:

--- a/fasteners/tests/test_process_lock.py
+++ b/fasteners/tests/test_process_lock.py
@@ -27,6 +27,8 @@ import time
 from fasteners import process_lock as pl
 from fasteners import test
 
+WIN32 = os.name == 'nt'
+
 
 class BrokenLock(pl.InterProcessLock):
     def __init__(self, name, errno_code):
@@ -177,6 +179,7 @@ class ProcessLockTest(test.TestCase):
         lock = pl.InterProcessLock(lock_file)
         self.assertRaises(threading.ThreadError, lock.release)
 
+    @test.testtools.skipIf(WIN32, "This test assumes a POSIX environment")
     def test_interprocess_lock(self):
         lock_file = os.path.join(self.lock_dir, 'lock')
 

--- a/fasteners/tests/test_process_lock.py
+++ b/fasteners/tests/test_process_lock.py
@@ -20,6 +20,7 @@ import errno
 import multiprocessing
 import os
 import shutil
+import sys
 import tempfile
 import threading
 import time

--- a/fasteners/tests/test_process_lock.py
+++ b/fasteners/tests/test_process_lock.py
@@ -101,7 +101,6 @@ def lock_files(lock_path, handles_dir, num_handles=50):
                 count += 1
                 pl.InterProcessLock._unlock(handle)
             except IOError:
-                print(os.getpid())
                 os._exit(2)
             finally:
                 handle.close()

--- a/fasteners/tests/test_process_lock.py
+++ b/fasteners/tests/test_process_lock.py
@@ -97,8 +97,6 @@ def lock_files(lock_path, handles_dir, num_handles=50):
         count = 0
         for handle in handles:
             try:
-                if count % 5:
-                    print(os.getpid(), count)
                 pl.InterProcessLock._trylock(handle)
                 count += 1
                 pl.InterProcessLock._unlock(handle)
@@ -188,7 +186,7 @@ class ProcessLockTest(test.TestCase):
         children = [multiprocessing.Process(target=lock_files, args=args)
                     for _ in range(num_processes)]
 
-        with scoped_child_processes(children, timeout=10, exitcode=0):
+        with scoped_child_processes(children, timeout=30, exitcode=0):
             pass
 
     def test_lock_externally(self):

--- a/fasteners/tests/test_process_lock.py
+++ b/fasteners/tests/test_process_lock.py
@@ -16,7 +16,6 @@
 #    under the License.
 
 import errno
-import fcntl
 import multiprocessing
 import os
 import shutil
@@ -124,9 +123,9 @@ class ProcessLockTest(test.TestCase):
                 count = 0
                 for handle in handles:
                     try:
-                        fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                        pl.InterProcessLock.trylock(handle)
                         count += 1
-                        fcntl.flock(handle, fcntl.LOCK_UN)
+                        pl.InterProcessLock.unlock(handle)
                     except IOError:
                         os._exit(2)
                     finally:


### PR DESCRIPTION
The `test_process_lock` module was totally busted on windows. This cleans it up and gets everything working. There is a decent amount of code that just had to be moved to the top level of the module as helper functions because cross-process pickling on Windows is apparently less robust.

It also changes to `multiprocessing` instead of relying on POSIX `fork()` behavior.

Closes #22 