### PR TITLE
Adjust setup.py and _utils.py to use time.monotonic for Python 3.4+

### DIFF
--- a/fasteners/_utils.py
+++ b/fasteners/_utils.py
@@ -36,7 +36,10 @@ except (ImportError, AttributeError):
 
 import six
 
-from monotonic import monotonic as now  # noqa
+try:
+    from time import monotonic as now
+except (ImportError, AttributeError):
+    from monotonic import monotonic as now  # noqa
 
 # log level for low-level debugging
 BLATHER = 5

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open("README.rst", "r") as readme:
 
 install_requires = [
     'six',
-    'monotonic>=0.1',
+    'monotonic>=0.1;python_version<"3.4"',
 ]
 
 setup(


### PR DESCRIPTION
This adjusts fasteners to use the built-in time.monotonic instead of monotonic when using Python 3.4+