### PR TITLE
Introduce native OS-supported shared/exclusive locking on the filesystem

### DIFF
--- a/doc/source/api/fs_lock.rst
+++ b/doc/source/api/fs_lock.rst
@@ -1,0 +1,10 @@
+====================
+ Filesystem Locking
+====================
+
+-------
+Classes
+-------
+
+.. autoclass:: fasteners.fs_lock.FileLock
+   :members:

--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -168,3 +168,14 @@ Try lock
             print("I got the lock")
         else:
             print("I did not get the lock")
+
+
+.. code-block:: python
+
+    from fasteners.lock import try_lock_shared
+
+    with try_lock_shared(lk) as got_lock:
+        if gotten:
+            print("I got the lock")
+        else:
+            print("I did not get the lock")

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -9,6 +9,7 @@ A python `package`_ that provides useful locks.
    :maxdepth: 3
 
    api/lock
+   api/fs_lock
    api/process_lock
 
    examples

--- a/fasteners/_win32_fs_lockapi.py
+++ b/fasteners/_win32_fs_lockapi.py
@@ -1,0 +1,78 @@
+"""
+Exposes the minimal amount of code to use Win32 native file locking. We only
+need two APIs, so this is far lighter weight than pulling in all of pywin32.
+"""
+
+import os
+
+if os.name != 'nt':
+    raise RuntimeError(
+        'fasteners._win32_lockapi is only importable on Windows')
+
+import msvcrt
+from ctypes import Structure, Union, windll, c_void_p, pointer, POINTER
+from ctypes.wintypes import DWORD, HANDLE, BOOL
+
+
+# Definitions for OVERLAPPED.
+# Refer: https://docs.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-overlapped
+class _DummyStruct(Structure):
+    _fields_ = [
+        ('Offset', DWORD),
+        ('OffsetHigh', DWORD),
+    ]
+
+
+class _DummyUnion(Union):
+    _fields_ = [
+        ('_offsets', _DummyStruct),
+        ('Pointer', c_void_p),
+    ]
+
+
+class OVERLAPPED(Structure):
+    _fields_ = [
+        ('Internal', c_void_p),
+        ('InternalHigh', c_void_p),
+        ('_offset_or_ptr', _DummyUnion),
+        ('hEvent', HANDLE),
+    ]
+
+
+# Refer: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-lockfileex
+LockFileEx = windll.kernel32.LockFileEx
+LockFileEx.argtypes = [
+    HANDLE,
+    DWORD,
+    DWORD,
+    DWORD,
+    DWORD,
+    POINTER(OVERLAPPED),
+]
+LockFileEx.restype = BOOL
+
+# Refer: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-unlockfile
+UnlockFileEx = windll.kernel32.UnlockFileEx
+UnlockFileEx.argtypes = [
+    HANDLE,
+    DWORD,
+    DWORD,
+    DWORD,
+    POINTER(OVERLAPPED),
+]
+UnlockFileEx.restype = BOOL
+
+# Errors/flags
+GetLastError = windll.kernel32.GetLastError
+LOCKFILE_EXCLUSIVE_LOCK = 0x02
+LOCKFILE_FAIL_IMMEDIATELY = 0x01
+ERROR_IO_PENDING = 997
+
+
+def get_win_handle(fd):
+    """
+    Given a file or file descriptor, obtain the `HANDLE` to which it corresponds
+    """
+    if hasattr(fd, 'fileno'):
+        fd = fd.fileno()
+    return msvcrt.get_osfhandle(fd)

--- a/fasteners/fs_lock.py
+++ b/fasteners/fs_lock.py
@@ -1,0 +1,170 @@
+"""
+Implements locking utilities, including filesystem-based OS-assisted
+shared/exclusive advisory locking.
+"""
+
+import ctypes
+import errno
+import os
+from contextlib import contextmanager
+
+from . import lock
+
+
+class FileLock(object):
+    """
+    Implements OS-supported shared and exclusive locking using the native
+    platform APIs. No matter how the process is terminated, the system will
+    ensure that the locks are released.
+
+    :param path: The path to the file that represents the lock
+    :param region_start: The beginning of the region in the file to lock
+    :param region_length: The size of the region to be locked
+    """
+    def __init__(self, path, region_start=0, region_length=1):
+        #: The path to the file which is used as a lock.
+        self.path = path
+        self.region_start = region_start
+        self.region_length = region_length
+        self._file = None
+        if os.name == 'nt':
+            self._acquire = self._acquire_nt
+            self._release = self._release_nt
+        else:
+            self._acquire = self._acquire_unix
+            self._release = self._release_unix
+
+    def _acquire_unix(self, exclusive, block):
+        # Build the flags
+        import fcntl
+        lk_flags = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
+        if not block:
+            lk_flags |= fcntl.LOCK_NB
+        # Obtain a new file descriptor
+        assert self._file is None, 'FileLock() cannot be used recursively'
+        pardir = os.path.dirname(self.path)
+        if not os.path.exists(pardir):
+            os.makedirs(pardir)
+
+        file_ = open(self.path, 'wb+')
+        # Take the lock
+        try:
+            fcntl.lockf(file_.fileno(), lk_flags, self.region_length, self.region_start)
+        except OSError as exc:
+            file_.close()
+            if exc.errno in (errno.EAGAIN, errno.EACCES):
+                # Failed to take the lock. Never reached when block=True
+                return False
+            # Some other exception...
+            raise
+        except:
+            file_.close()
+            raise
+        # Got it!
+        self._file = file_
+        return True
+
+    def _release_unix(self):
+        assert self._file is not None, 'Cannot release() a lock that is not held'
+        import fcntl
+        fcntl.lockf(self._file.fileno(), fcntl.LOCK_UN, self.region_length, self.region_start)
+        self._file.close()
+        self._file = None
+
+    def _acquire_nt(self, exclusive, block):
+        assert self._file is None, 'FileLock() cannot be used recursively'
+
+        from . import _win32_lockapi
+
+        flags = 0
+        if exclusive:
+            flags |= _win32_lockapi.LOCKFILE_EXCLUSIVE_LOCK
+        if not block:
+            flags |= _win32_lockapi.LOCKFILE_FAIL_IMMEDIATELY
+
+        pardir = os.path.dirname(self.path)
+        if not os.path.exists(pardir):
+            os.makedirs(pardir)
+        file_ = open(self.path, 'wb+')
+        okay = _win32_lockapi.LockFileEx(
+            _win32_lockapi.get_win_handle(self._file),
+            flags,
+            0,
+            0,
+            0,
+            ctypes.pointer(_win32_lockapi.OVERLAPPED()),
+        )
+        if not okay:
+            file_.close()
+            import contextlib
+            last_error = _win32_lockapi.GetLastError()
+            if last_error != _win32_lockapi.ERROR_IO_PENDING:
+                raise OSError(last_error)
+            return False
+        self._file = file_
+        return True
+
+    def _release_nt(self):
+        assert self._file is not None, 'Cannot release() a lock that is not held'
+        from . import _win32_lockapi
+        okay = _win32_lockapi.UnlockFileEx(
+            _win32_lockapi.get_win_handle(self._file),
+            0,
+            0,
+            0,
+            ctypes.pointer(_win32_lockapi.OVERLAPPED()),
+        )
+        if not okay:
+            raise OSError(_win32_lockapi.GetLastError())
+
+        self._file.close()
+        self._file = None
+
+    def acquire_shared(self, block=True):
+        """
+        Acquire shared ownership.
+        """
+        self._acquire(exclusive=False, block=block)
+
+    def acquire(self, block=True):
+        """
+        Acquire exclusive ownership.
+        """
+        self._acquire(exclusive=True, block=block)
+
+    def release_shared(self):
+        """
+        Release shared ownership of the resource.
+        """
+        self._release()
+
+    def release(self):
+        """
+        Release exclusive ownership of the resource.
+        """
+        self._release()
+
+    def holds_lock(self):
+        """
+        Determine if a lock is currently held.
+        """
+        return self._file is not None
+
+    def __enter__(self):
+        """
+        Obtain an exclusive lock.
+        """
+        self.acquire(block=True)
+
+    def __exit__(self, _exc_type, _exc, _exc_tb):
+        """
+        Release the lock.
+        """
+        self.release()
+
+    @property
+    def shared(self):
+        """
+        Property returns a context manager that will hold a shared lock.
+        """
+        return lock.lock_shared(self)

--- a/fasteners/lock.py
+++ b/fasteners/lock.py
@@ -303,3 +303,32 @@ def locked(*args, **kwargs):
             return decorator(args[0])
         else:
             return decorator
+
+
+@contextlib.contextmanager
+def lock_shared(lk):
+    """
+    Context manager which holds shared ownership over the given lockable object
+    ``lk``. Requires ``.acquire_shared()`` and ``.release_shared()`` methods on
+    ``lk``.
+    """
+    lk.acquire_shared()
+    try:
+        yield
+    finally:
+        lk.release_shared()
+
+
+@contextlib.contextmanager
+def try_lock_shared(lk):
+    """
+    Context manager which tries to obtain shared ownership over the lock.
+    Yields a ``bool`` of whether the lock was obtained. Requires
+    ``.acquire_shared()`` and ``.release_shared()`` methods on ``lk``.
+    """
+    got_lock = lk.acquire_shared(False)
+    try:
+        yield got_lock
+    finally:
+        if got_lock:
+            lk.release_shared()

--- a/fasteners/tests/test_fs_lock.py
+++ b/fasteners/tests/test_fs_lock.py
@@ -1,0 +1,41 @@
+import unittest
+import os.path
+import tempfile
+
+from fasteners import fs_lock, lock
+
+
+class FileLockTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.lock_path = os.path.join(self.temp_dir, 'lock.txt')
+        self.lk = fs_lock.FileLock(self.lock_path)
+
+    def tearDown(self):
+        if os.path.exists(self.lock_path):
+            os.unlink(self.lock_path)
+        os.rmdir(self.temp_dir)
+
+    def test_acquire(self):
+        self.lk.acquire()
+        try:
+            self.assertTrue(self.lk.holds_lock())
+        finally:
+            self.lk.release()
+        self.assertFalse(self.lk.holds_lock())
+
+    def test_acquire_shared(self):
+        self.lk.acquire_shared()
+        try:
+            self.assertTrue(self.lk.holds_lock())
+        finally:
+            self.lk.release_shared()
+        self.assertFalse(self.lk.holds_lock())
+
+    def test_acquire_ctx(self):
+        with self.lk:
+            self.assertTrue(self.lk.holds_lock())
+
+    def test_acquire_shared_ctx(self):
+        with self.lk.shared:
+            self.assertTrue(self.lk.holds_lock())


### PR DESCRIPTION
The existing interprocess locking doesn't exposed shared lock ownership (read/write locking). This implements shared and exclusive locks using the native APIs rather than the limited APIs exposed by the Python stdlib.