### PR TITLE
Remove unused import of eventlet

### DIFF
--- a/fasteners/lock.py
+++ b/fasteners/lock.py
@@ -25,15 +25,6 @@ from fasteners import _utils
 
 import six
 
-try:
-    # Used for the reader-writer lock get the right
-    # thread 'hack' (needed below).
-    import eventlet
-    from eventlet import patcher as eventlet_patcher
-except ImportError:
-    eventlet = None
-    eventlet_patcher = None
-
 
 def read_locked(*args, **kwargs):
     """Acquires & releases a read lock around call into decorated method.


### PR DESCRIPTION
Significantly reduces import time. 

On this Windows workstation, the time for `import fasteners` decreases from ~0.4 s to <0.03 s.

The use of eventlet was removed in https://github.com/harlowja/fasteners/pull/33.