### PR TITLE
lmplements the inter-process readers writer lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.egg-info
+__pycache__

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,50 @@
 language: python
-python:
-  - "2.7"
-  - "3.4"
-  - "pypy"
-# https://github.com/travis-ci/travis-ci/issues/4794
-matrix:
+
+jobs:
   include:
-    - python: "3.5"
+    - name: "Python 2.7 on Linux"
+      python: 2.7
+      before_install:
+        - pip install .
+        - pip install -r test-requirements.txt
+
+    - name: "Python 3.6 on Linux"
+      python: 3.6
+      before_install:
+        - pip install .
+        - pip install -r test-requirements.txt
+
+    - name: "Python 3.8 on Linux"
+      python: 3.8
+      before_install:
+        - pip install .
+        - pip install -r test-requirements.txt
+
+    - name: "Python 3.? on macOS"
+      os: osx
+      osx_image: xcode12
+      language: shell
+      before_install:
+        - python3 --version
+        - pip3 install -U pip
+        - pip3 install --user .
+        - pip3 install --user -r test-requirements.txt
+      script:
+        - python3 -m nose
+
+    - name: "Python 3.6 on Windows"
+      os: windows
+      language: shell
+      before_install:
+        - choco install python --version 3.6
+        - python -m pip install --upgrade pip
+        - pip install .
+        - pip install -r test-requirements.txt
+      env: PATH=/c/Python36:/c/Python36/Scripts:$PATH
+
 # command to install dependencies
 install:
-  - "pip install ."
-  - "pip install -r test-requirements.txt"
+  - ls
+
 # command to run tests
 script: nosetests
-

--- a/README.rst
+++ b/README.rst
@@ -22,31 +22,41 @@ Fasteners
 Overview
 --------
 
-A python `package`_ that provides useful locks.
+A python `package`_ that provides cross-platform inter-thread and inter-process
+locks.
 
-It includes the following.
+It includes the following:
 
-Locking decorator
-*****************
+Inter-thread locking decorator
+******************************
 
 * Helpful ``locked`` decorator (that acquires instance
   objects lock(s) and acquires on method entry and
   releases on method exit).
 
-Reader-writer locks
-*******************
+Inter-thread reader writer locks
+********************************
 
 * Multiple readers (at the same time).
-* Single writers (blocking any readers).
+* Single writer (blocking any readers).
 * Helpful ``read_locked`` and ``write_locked`` decorators.
 
-Inter-process locks
-*******************
+Inter-process locking decorator
+*******************************
 
-* Single writer using file based locking (these automatically
-  release on process exit, even if ``__release__`` or
+* Single process lock using a file based locking that automatically
+  release on process exit (even if ``__release__`` or
   ``__exit__`` is never called).
 * Helpful ``interprocess_locked`` decorator.
+
+Inter-process reader writer lock
+********************************
+
+* Multiple readers (at the same time)
+* Singer writer (blokcing any readers)
+* Can be used via ``interprocess_read_locked`` and ``interprocess_write_locked``
+  decorators, or ``read_lock`` and ``write_lock`` context managers.
+* Based on fcntl (Linux, OSX) and LockFileEx (Windows)
 
 Generic helpers
 ***************

--- a/doc/source/api/process_lock.rst
+++ b/doc/source/api/process_lock.rst
@@ -2,6 +2,56 @@
  Process lock
 ==============
 
+Fasteners inter-process locks are cross-platform and are released automatically
+if the process crashes. They are based on the platform specific locking
+mechanisms:
+
+* fcntl for posix (Linux and OSX)
+* LockFileEx (via pywin32) and \_locking (via msvcrt) for Windows
+
+The intersection of fcntl and LockFileEx features is quite small, hence you
+should always assume that:
+
+* Locks are advisory. They do not prevent the modification of the locked file
+  by other processes.
+
+* Locks can be unintentionally released by simply opening and closing the file
+  descriptor, so lock files must be accessed only using provided abstractions.
+
+* Locks are not reentrant_. An attempt to acquire a lock multiple times can
+  result in a deadlock or a crash upon a release of the lock.
+
+* Reader writer locks are not upgradeable_. An attempt to get a reader's lock
+  while holding a writer's lock (or vice versa) can result in a deadlock or a
+  crash upon a release of the lock.
+
+* There are no guarantees regarding usage by multiple threads in a
+  single process. The locks work only between processes.
+
+To learn more about the complications of locking on different platforms we
+recommend the following resources:
+
+* `File locking in Linux (blog post)`_
+
+* `On the Brokenness of File Locking (blog post)`_
+
+* `Everything you never wanted to know about file locking`_
+
+* `Windows NT Files -- Locking (pywin32 docs)`_
+
+* `_locking (Windows Dev Center)`_
+
+* `LockFileEx function (Windows Dev Center)`_
+
+.. _upgradeable: https://en.wikipedia.org/wiki/Readers%E2%80%93writer_lock#Upgradable_RW_lock>
+.. _reentrant: https://en.wikipedia.org/wiki/Reentrant_mutex
+.. _File locking in Linux (blog post): https://gavv.github.io/articles/file-locks/
+.. _On the Brokenness of File Locking (blog post): http://0pointer.de/blog/projects/locking.html
+.. _Windows NT Files -- Locking (pywin32 docs): http://timgolden.me.uk/pywin32-docs/Windows_NT_Files_.2d.2d_Locking.html
+.. _\_locking (Windows Dev Center): https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/locking?view=vs-2019
+.. _LockFileEx function (Windows Dev Center): https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-lockfileex
+.. _Everything you never wanted to know about file locking: https://chris.improbable.org/2010/12/16/everything-you-never-wanted-to-know-about-file-locking/
+
 -------
 Classes
 -------
@@ -12,8 +62,19 @@ Classes
 .. autoclass:: fasteners.process_lock._InterProcessLock
    :members:
 
+.. autoclass:: fasteners.process_lock.InterProcessReaderWriterLock
+   :members:
+
+.. autoclass:: fasteners.process_lock._InterProcessReaderWriterLock
+   :members:
+
+
 ----------
 Decorators
 ----------
 
 .. autofunction:: fasteners.process_lock.interprocess_locked
+
+.. autofunction:: fasteners.process_lock.interprocess_read_locked
+
+.. autofunction:: fasteners.process_lock.interprocess_write_locked

--- a/fasteners/__init__.py
+++ b/fasteners/__init__.py
@@ -22,10 +22,11 @@ from __future__ import absolute_import
 
 from fasteners.lock import locked  # noqa
 from fasteners.lock import read_locked  # noqa
+from fasteners.lock import ReaderWriterLock  # noqa
 from fasteners.lock import try_lock  # noqa
 from fasteners.lock import write_locked  # noqa
-
-from fasteners.lock import ReaderWriterLock  # noqa
-from fasteners.process_lock import InterProcessLock  # noqa
-
 from fasteners.process_lock import interprocess_locked  # noqa
+from fasteners.process_lock import interprocess_read_locked  # noqa
+from fasteners.process_lock import interprocess_write_locked  # noqa
+from fasteners.process_lock import InterProcessLock  # noqa
+from fasteners.process_lock import InterProcessReaderWriterLock  # noqa

--- a/fasteners/process_lock.py
+++ b/fasteners/process_lock.py
@@ -14,7 +14,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-
+from contextlib import contextmanager
 import errno
 import logging
 import os
@@ -50,28 +50,7 @@ def _ensure_tree(path):
 
 
 class _InterProcessLock(object):
-    """An interprocess locking implementation.
-
-    This is a lock implementation which allows multiple locks, working around
-    issues like http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=632857 and
-    does not require any cleanup. Since the lock is always held on a file
-    descriptor rather than outside of the process, the lock gets dropped
-    automatically if the process crashes, even if ``__exit__`` is not
-    executed.
-
-    There are no guarantees regarding usage by multiple threads in a
-    single process here. This lock works only between processes.
-
-    Note these locks are released when the descriptor is closed, so it's not
-    safe to close the file descriptor while another thread holds the
-    lock. Just opening and closing the lock file can break synchronization,
-    so lock files must be accessed only using this abstraction.
-
-    .. warning::
-
-       It is quite useful to read before using (to understand
-       the risks involved): http://0pointer.de/blog/projects/locking.html
-    """
+    """An interprocess lock."""
 
     MAX_DELAY = 0.1
     """
@@ -220,11 +199,214 @@ class _InterProcessLock(object):
         self._unlock(self.lockfile)
 
     @staticmethod
-    def _trylock():
+    def _trylock(lockfile):
         raise NotImplementedError()
 
     @staticmethod
-    def _unlock():
+    def _unlock(lockfile):
+        raise NotImplementedError()
+
+
+class _InterProcessReaderWriterLock(object):
+    """An interprocess readers writer lock."""
+
+    MAX_DELAY = 0.1
+    """
+    Default maximum delay we will wait to try to acquire the lock (when
+    it's busy/being held by another process).
+    """
+
+    DELAY_INCREMENT = 0.01
+    """
+    Default increment we will use (up to max delay) after each attempt before
+    next attempt to acquire the lock. For example if 3 attempts have been made
+    the calling thread will sleep (0.01 * 3) before the next attempt to
+    acquire the lock (and repeat).
+    """
+
+    def __init__(self, path, sleep_func=time.sleep, logger=None):
+        self.lockfile = None
+        self.path = _utils.canonicalize_path(path)
+        self.sleep_func = sleep_func
+        self.logger = _utils.pick_first_not_none(logger, LOG)
+
+    def _try_acquire(self, blocking, watch, exclusive):
+        try:
+            gotten = self._trylock(self.lockfile, exclusive)
+        except Exception as e:
+            raise threading.ThreadError(
+                "Unable to acquire lock on {} due to {}!".format(self.path, e))
+
+        if gotten:
+            return True
+
+        if not blocking or watch.expired():
+            return False
+
+        raise _utils.RetryAgain()
+
+    def _do_open(self):
+        basedir = os.path.dirname(self.path)
+        if basedir:
+            made_basedir = _ensure_tree(basedir)
+            if made_basedir:
+                self.logger.log(_utils.BLATHER,
+                                'Created lock base path `%s`', basedir)
+        if self.lockfile is None:
+            self.lockfile = self._get_handle(self.path)
+
+    def acquire_read_lock(self, blocking=True,
+                          delay=DELAY_INCREMENT, max_delay=MAX_DELAY,
+                          timeout=None):
+
+        """Attempt to acquire a reader's lock.
+
+        :param blocking: whether to wait forever to try to acquire the lock
+        :type blocking: bool
+        :param delay: when blocking this is the delay time in seconds that
+                      will be added after each failed acquisition
+        :type delay: int/float
+        :param max_delay: the maximum delay to have (this limits the
+                          accumulated delay(s) added after each failed
+                          acquisition)
+        :type max_delay: int/float
+        :param timeout: an optional timeout (limits how long blocking
+                        will occur for)
+        :type timeout: int/float
+        :returns: whether or not the acquisition succeeded
+        :rtype: bool
+        """
+        return self._acquire(blocking, delay, max_delay, timeout, exclusive=False)
+
+    def acquire_write_lock(self, blocking=True,
+                           delay=DELAY_INCREMENT, max_delay=MAX_DELAY,
+                           timeout=None):
+
+        """Attempt to acquire a writer's lock.
+
+        :param blocking: whether to wait forever to try to acquire the lock
+        :type blocking: bool
+        :param delay: when blocking this is the delay time in seconds that
+                      will be added after each failed acquisition
+        :type delay: int/float
+        :param max_delay: the maximum delay to have (this limits the
+                          accumulated delay(s) added after each failed
+                          acquisition)
+        :type max_delay: int/float
+        :param timeout: an optional timeout (limits how long blocking
+                        will occur for)
+        :type timeout: int/float
+        :returns: whether or not the acquisition succeeded
+        :rtype: bool
+        """
+        return self._acquire(blocking, delay, max_delay, timeout, exclusive=True)
+
+    def _acquire(self, blocking=True,
+                 delay=DELAY_INCREMENT, max_delay=MAX_DELAY,
+                 timeout=None, exclusive=True):
+
+        if delay < 0:
+            raise ValueError("Delay must be greater than or equal to zero")
+        if timeout is not None and timeout < 0:
+            raise ValueError("Timeout must be greater than or equal to zero")
+        if delay >= max_delay:
+            max_delay = delay
+        self._do_open()
+        watch = _utils.StopWatch(duration=timeout)
+        r = _utils.Retry(delay, max_delay,
+                         sleep_func=self.sleep_func, watch=watch)
+        with watch:
+            gotten = r(self._try_acquire, blocking, watch, exclusive)
+        if not gotten:
+            return False
+        else:
+            self.logger.log(_utils.BLATHER,
+                            "Acquired file lock `%s` after waiting %0.3fs [%s"
+                            " attempts were required]", self.path,
+                            watch.elapsed(), r.attempts)
+            return True
+
+    def _do_close(self):
+        if self.lockfile is not None:
+            self._close_handle(self.lockfile)
+            self.lockfile = None
+
+    def release_write_lock(self):
+        """Release the writer's lock."""
+        try:
+            self._unlock(self.lockfile)
+        except IOError:
+            self.logger.exception("Could not unlock the acquired lock opened"
+                                  " on `%s`", self.path)
+        else:
+            try:
+                self._do_close()
+            except IOError:
+                self.logger.exception("Could not close the file handle"
+                                      " opened on `%s`", self.path)
+            else:
+                self.logger.log(_utils.BLATHER,
+                                "Unlocked and closed file lock open on"
+                                " `%s`", self.path)
+
+    def release_read_lock(self):
+        """Release the reader's lock."""
+        try:
+            self._unlock(self.lockfile)
+        except IOError:
+            self.logger.exception("Could not unlock the acquired lock opened"
+                                  " on `%s`", self.path)
+        else:
+            try:
+                self._do_close()
+            except IOError:
+                self.logger.exception("Could not close the file handle"
+                                      " opened on `%s`", self.path)
+            else:
+                self.logger.log(_utils.BLATHER,
+                                "Unlocked and closed file lock open on"
+                                " `%s`", self.path)
+
+    @contextmanager
+    def write_lock(self, delay=DELAY_INCREMENT, max_delay=MAX_DELAY):
+
+        gotten = self.acquire_write_lock(blocking=True, delay=delay,
+                                         max_delay=max_delay, timeout=None)
+
+        if not gotten:
+            # This shouldn't happen, but just in case...
+            raise threading.ThreadError("Unable to acquire a file lock"
+                                        " on `%s` (when used as a"
+                                        " context manager)" % self.path)
+        try:
+            yield
+        finally:
+            self.release_write_lock()
+
+    @contextmanager
+    def read_lock(self, delay=DELAY_INCREMENT, max_delay=MAX_DELAY):
+
+        self.acquire_read_lock(blocking=True, delay=delay,
+                               max_delay=max_delay, timeout=None)
+        try:
+            yield
+        finally:
+            self.release_read_lock()
+
+    @staticmethod
+    def _trylock(lockfile, exclusive):
+        raise NotImplementedError()
+
+    @staticmethod
+    def _unlock(lockfile):
+        raise NotImplementedError()
+
+    @staticmethod
+    def _get_handle(path):
+        raise NotImplementedError()
+
+    @staticmethod
+    def _close_handle(lockfile):
         raise NotImplementedError()
 
 
@@ -254,12 +436,130 @@ class _FcntlLock(_InterProcessLock):
         fcntl.lockf(lockfile, fcntl.LOCK_UN)
 
 
+class _WindowsInterProcessReaderWriterLock(_InterProcessReaderWriterLock):
+    """Interprocess readers writer lock implementation that works on windows
+    systems."""
+
+    @staticmethod
+    def _trylock(lockfile, exclusive):
+
+        if exclusive:
+            flags = win32con.LOCKFILE_FAIL_IMMEDIATELY | win32con.LOCKFILE_EXCLUSIVE_LOCK
+        else:
+            flags = win32con.LOCKFILE_FAIL_IMMEDIATELY
+
+        try:
+            win32file.LockFileEx(lockfile, flags, 0, -0x10000, pywintypes.OVERLAPPED())
+            return True
+        except pywintypes.error as e:
+            if e.args[0] == 33:
+                return False
+            else:
+                raise e
+
+    @staticmethod
+    def _unlock(lockfile):
+        win32file.UnlockFileEx(lockfile, 0, -0x10000, pywintypes.OVERLAPPED())
+
+    @staticmethod
+    def _get_handle(path):
+        secur_att = win32security.SECURITY_ATTRIBUTES()
+        secur_att.Initialize()
+        return win32file.CreateFile(path.decode('utf-8'),
+                                    win32con.GENERIC_READ | win32con.GENERIC_WRITE,
+                                    win32con.FILE_SHARE_READ | win32con.FILE_SHARE_WRITE,
+                                    secur_att,
+                                    win32con.OPEN_ALWAYS,
+                                    win32con.FILE_ATTRIBUTE_NORMAL, 0)
+
+    @staticmethod
+    def _close_handle(lockfile):
+        lockfile.Close()
+
+
+class _FcntlInterProcessReaderWriterLock(_InterProcessReaderWriterLock):
+    """Interprocess readers writer lock implementation that works on posix
+    systems."""
+
+    @staticmethod
+    def _trylock(lockfile, exclusive):
+
+        if exclusive:
+            flags = fcntl.LOCK_EX | fcntl.LOCK_NB
+        else:
+            flags = fcntl.LOCK_SH | fcntl.LOCK_NB
+
+        try:
+            fcntl.lockf(lockfile, flags)
+            return True
+        except (IOError, OSError) as e:
+            if e.errno in (errno.EACCES, errno.EAGAIN):
+                return False
+            else:
+                raise e
+
+    @staticmethod
+    def _unlock(lockfile):
+        fcntl.lockf(lockfile, fcntl.LOCK_UN)
+
+    @staticmethod
+    def _get_handle(path):
+        return open(path, 'a+')
+
+    @staticmethod
+    def _close_handle(lockfile):
+        lockfile.close()
+
+
 if os.name == 'nt':
     import msvcrt
+    import pywintypes
+    import win32con
+    import win32file
+    import win32security
+
     InterProcessLock = _WindowsLock
+    InterProcessReaderWriterLock = _WindowsInterProcessReaderWriterLock
+
 else:
     import fcntl
+
     InterProcessLock = _FcntlLock
+    InterProcessReaderWriterLock = _FcntlInterProcessReaderWriterLock
+
+
+def interprocess_write_locked(path):
+    """Acquires & releases an interprocess read lock around the call into
+    the decorated function"""
+
+    lock = InterProcessReaderWriterLock(path)
+
+    def decorator(f):
+        @six.wraps(f)
+        def wrapper(*args, **kwargs):
+            with lock.write_lock():
+                return f(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def interprocess_read_locked(path):
+    """Acquires & releases an interprocess read lock around the call into
+    the decorated function"""
+
+    lock = InterProcessReaderWriterLock(path)
+
+    def decorator(f):
+        @six.wraps(f)
+        def wrapper(*args, **kwargs):
+            with lock.read_lock():
+                return f(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
 
 
 def interprocess_locked(path):
@@ -269,7 +569,6 @@ def interprocess_locked(path):
     lock = InterProcessLock(path)
 
     def decorator(f):
-
         @six.wraps(f)
         def wrapper(*args, **kwargs):
             with lock:

--- a/fasteners/tests/test_reader_writer_lock.py
+++ b/fasteners/tests/test_reader_writer_lock.py
@@ -1,0 +1,258 @@
+import os
+import random
+import shutil
+import tempfile
+import time
+from multiprocessing import Pool
+from multiprocessing import Process
+from pathlib import Path
+
+import more_itertools as mo
+from diskcache import Cache
+from diskcache import Deque
+from six import wraps
+
+from fasteners import test
+from fasteners._utils import StopWatch
+from fasteners.process_lock import InterProcessReaderWriterLock as ReaderWriterLock
+
+PROCESS_COUNT = 20
+
+
+def unpack(func):
+    @wraps(func)
+    def wrapper(arg_tuple):
+        return func(*arg_tuple)
+
+    return wrapper
+
+
+def run_doesnt_hang(disk_cache_dir, lock_file, type_):
+    lock = (ReaderWriterLock(lock_file).write_lock if type_ == 'w' else
+            ReaderWriterLock(lock_file).read_lock)
+    with lock():
+        with Cache(disk_cache_dir) as dc_:
+            dc_.incr(type_)
+
+
+@unpack
+def run_no_concurrent_writers(disk_cache_dir, lock_file):
+    watch = StopWatch(duration=1)
+    watch.start()
+
+    with Cache(disk_cache_dir) as dc_:
+        while not watch.expired():
+            no_concurrent_writers_acquire_check(dc_, lock_file)
+
+
+def no_concurrent_writers_acquire_check(dc_, lock_file):
+    with ReaderWriterLock(lock_file).write_lock():
+        if dc_.get('active_count', 0) >= 1:
+            dc_.incr('dups_count')
+        dc_.incr('active_count')
+        time.sleep(random.random() / 1000)
+        dc_.decr('active_count')
+        dc_.incr('visited_count')
+
+
+@unpack
+def run_no_cuncurrent_readers_writers(disk_cache_dir, lock_file):
+    watch = StopWatch(duration=1)
+    watch.start()
+
+    with Cache(disk_cache_dir) as dc_:
+        while not watch.expired():
+            no_concurrent_readers_writers_acquire_check(dc_, lock_file,
+                                                        random.choice([True, False]))
+
+
+def no_concurrent_readers_writers_acquire_check(dc_, lock_file, reader):
+    if reader:
+        lock_func = ReaderWriterLock(lock_file).read_lock
+    else:
+        lock_func = ReaderWriterLock(lock_file).write_lock
+    with lock_func():
+        if not reader:
+            if dc_.get('active_count', 0) >= 1:
+                dc_.incr('dups_count')
+        dc_.incr('active_count')
+        time.sleep(random.random() / 1000)
+        dc_.decr('active_count')
+        dc_.incr('visited_count')
+
+
+def run_reader_writer_chaotic(disk_cache_dir, lock_file, type_, blow_up):
+    lock = (ReaderWriterLock(lock_file).write_lock if type_ == 'w' else
+            ReaderWriterLock(lock_file).read_lock)
+    with lock():
+        with Cache(disk_cache_dir) as dc_:
+            dc_.incr(type_)
+        if blow_up:
+            raise RuntimeError()
+
+
+def reader_releases_lock_upon_crash_reader_lock(disk_cache_dir, lock_file, i):
+    with ReaderWriterLock(lock_file).read_lock():
+        with Cache(disk_cache_dir) as dc_:
+            dc_.set('pid{}'.format(i), os.getpid())
+        raise RuntimeError('')
+
+
+def reader_releases_lock_upon_crash_writer_lock(disk_cache_dir, lock_file, i):
+    ReaderWriterLock(lock_file).acquire_write_lock(timeout=5)
+    with Cache(disk_cache_dir) as dc_:
+        dc_.set('pid{}'.format(i), os.getpid())
+
+
+def run_writer_releases_lock_upon_crash(disk_cache_dir, lock_file, i, crash):
+    ReaderWriterLock(lock_file).acquire_write_lock(timeout=5)
+    with Cache(disk_cache_dir) as dc_:
+        dc_.set('pid{}'.format(i), os.getpid())
+    if crash:
+        raise RuntimeError('')
+
+
+class ProcessReaderWriterLock(test.TestCase):
+
+    def setUp(self):
+        super(ProcessReaderWriterLock, self).setUp()
+
+        lock_file = tempfile.NamedTemporaryFile()
+        lock_file.close()
+        self.lock_file = lock_file.name
+        self.disk_cache_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        super(ProcessReaderWriterLock, self).tearDown()
+
+        shutil.rmtree(self.disk_cache_dir, ignore_errors=True)
+        try:
+            os.remove(self.lock_file)
+        except OSError:
+            pass
+
+    def test_lock(self):
+
+        with ReaderWriterLock(self.lock_file).write_lock():
+            pass
+
+        with ReaderWriterLock(self.lock_file).read_lock():
+            pass
+
+    def test_no_concurrent_writers(self):
+        pool = Pool(PROCESS_COUNT)
+        pool.map(run_no_concurrent_writers, [(self.disk_cache_dir, self.lock_file)] * PROCESS_COUNT,
+                 chunksize=1)
+
+        with Cache(self.disk_cache_dir) as dc:
+            self.assertEqual(dc.get('active_count'), 0)
+            self.assertEqual(dc.get('dups_count'), None)
+            self.assertGreaterEqual(dc.get('visited_count'), 25)
+
+    def test_no_concurrent_readers_writers(self):
+        pool = Pool(PROCESS_COUNT)
+        pool.map(run_no_cuncurrent_readers_writers,
+                 [(self.disk_cache_dir, self.lock_file)] * PROCESS_COUNT, chunksize=1)
+
+        with Cache(self.disk_cache_dir) as dc:
+            self.assertEqual(dc.get('active_count'), 0)
+            self.assertEqual(dc.get('dups_count'), None)
+            self.assertGreaterEqual(dc.get('visited_count'), 10)
+
+    def test_writer_releases_lock_upon_crash(self):
+        p1 = Process(target=run_writer_releases_lock_upon_crash,
+                     args=(self.disk_cache_dir, self.lock_file, 1, True))
+        p2 = Process(target=run_writer_releases_lock_upon_crash,
+                     args=(self.disk_cache_dir, self.lock_file, 2, False))
+
+        p1.start()
+        p1.join()
+
+        p2.start()
+        p2.join()
+
+        with Cache(self.disk_cache_dir) as dc:
+            assert dc.get('pid1') != dc.get('pid2')
+
+        self.assertNotEqual(0, p1.exitcode)
+        self.assertEqual(0, p2.exitcode)
+
+    def test_reader_releases_lock_upon_crash(self):
+        p1 = Process(target=reader_releases_lock_upon_crash_reader_lock,
+                     args=(self.disk_cache_dir, self.lock_file, 1))
+        p2 = Process(target=reader_releases_lock_upon_crash_writer_lock,
+                     args=(self.disk_cache_dir, self.lock_file, 2))
+
+        p1.start()
+        p1.join()
+
+        p2.start()
+        p2.join()
+
+        with Cache(self.disk_cache_dir) as dc:
+            assert dc.get('pid1') != dc.get('pid2')
+
+        self.assertNotEqual(0, p1.exitcode)
+        self.assertEqual(0, p2.exitcode)
+
+    def test_multi_reader_multi_writer(self):
+        visits = _spawn_variation(Path(self.disk_cache_dir),
+                                  Path(self.lock_file), 10, 10)
+
+        self.assertEqual(20 * 2, len(visits))
+        self._assert_valid(visits)
+
+    def test_multi_reader_single_writer(self):
+        visits = _spawn_variation(Path(self.disk_cache_dir),
+                                  Path(self.lock_file), 9, 1)
+
+        self.assertEqual(10 * 2, len(visits))
+        self._assert_valid(visits)
+
+    def test_multi_writer(self):
+        visits = _spawn_variation(Path(self.disk_cache_dir),
+                                  Path(self.lock_file), 0, 10)
+
+        self.assertEqual(10 * 2, len(visits))
+        self._assert_valid(visits)
+
+    def _assert_valid(self, visits):
+        """Check if writes dont overlap other writes and reads"""
+
+        # check that writes open and close consequently
+        write_blocks = mo.split_at(visits, lambda x: x[1] == 'r')
+        for write_block in write_blocks:
+            for v1, v2 in mo.chunked(write_block, 2):
+                self.assertEqual(v1[0], v2[0])
+
+        # check that reads open and close in groups between writes
+        read_blocks = mo.split_at(visits, lambda x: x[1] == 'w')
+        for read_block in read_blocks:
+            for v1, v2 in mo.chunked(sorted(read_block), 2):
+                self.assertEqual(v1[0], v2[0])
+
+
+def _spawn_variation(disk_cache_dir, lock_file, readers, writers):
+    visits = Deque(directory=str(disk_cache_dir / 'w'))
+    pool = Pool(readers + writers)
+    pool.map(_spawling, [(lock_file, visits, type_) for type_ in ['w'] * writers + ['r'] * readers])
+    return visits
+
+
+@unpack
+def _spawling(lock_file, visits, type_):
+    lock = ReaderWriterLock(lock_file)
+
+    if type_ == 'w':
+        lock.acquire_write_lock(timeout=5)
+    else:
+        lock.acquire_read_lock(timeout=5)
+
+    visits.append((os.getpid(), type_))
+    time.sleep(random.random() / 100 + 0.01)
+    visits.append((os.getpid(), type_))
+
+    if type_ == 'w':
+        lock.release_write_lock()
+    else:
+        lock.release_read_lock()

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ with open("README.rst", "r") as readme:
 install_requires = [
     'six',
     'monotonic>=0.1',
+    'pywin32;platform_system=="Windows"'
 ]
 
 setup(

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,8 @@
+diskcache
+more_itertools
 nose
 testtools
 futures
+pathlib
 sphinx
 sphinx-rtd-theme


### PR DESCRIPTION
This PR implements an inter-process readers writer lock, as suggested in https://github.com/harlowja/fasteners/issues/42.

I tried to stay very close to the existing code, in particular the structure, naming conventions, supported versions and the API. I took a bit more liberties with refreshing the documentation and README file, as well as fixed travis and added a gitignore.

I'm a bit unhappy that the intersection of windows and unix lock features is very small, but I don't know what to do about that apart from trying to build a readers writer locks myself, from lower level primitives. I'm not sure it is easy to do that.

Let me know what you think!