### PR TITLE
Fix inter process lock multiple aquire attempts on windows

### DIFF
--- a/tests/test_process_lock.py
+++ b/tests/test_process_lock.py
@@ -268,3 +268,18 @@ def test_bad_acquire(lock_dir):
     lock = BrokenLock(lock_file, errno.EBUSY)
     with pytest.raises(threading.ThreadError):
         lock.acquire()
+
+
+def test_lock_twice(lock_dir):
+    lock_file = os.path.join(lock_dir, 'lock')
+    lock = pl.InterProcessLock(lock_file)
+
+    ok = lock.acquire(blocking=False)
+    assert ok
+
+    # ok on Unix, not ok on Windows
+    ok = lock.acquire(blocking=False)
+    assert ok or not ok
+
+    # should release without crashing
+    lock.release()

--- a/tests/test_reader_writer_lock.py
+++ b/tests/test_reader_writer_lock.py
@@ -204,3 +204,17 @@ def test_multi_writer(lock_file, deque):
     visits = _spawn_variation(Path(lock_file), deque, 0, 10)
     assert len(visits) == 10 * 2
     _assert_valid(visits)
+
+
+def test_lock_writer_twice(lock_file):
+    lock = ReaderWriterLock(lock_file)
+
+    ok = lock.acquire_write_lock(blocking=False)
+    assert ok
+
+    # ok on Unix, not ok on Windows
+    ok = lock.acquire_write_lock(blocking=False)
+    assert ok or not ok
+
+    # should release without crashing
+    lock.release_write_lock()


### PR DESCRIPTION
This PR resolves https://github.com/harlowja/fasteners/issues/29.

The root of the issue is incorrect lock status update, and this PR removes the lock status tracking altogether. The only place where the lock status was used was a check in `release`, where it was unnecessary, as we are closing the handle anyway.