### PR TITLE
Fix InterProcessReaderWriterLock context manager example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ import fasteners
 rw_lock = fasteners.ReaderWriterLock()                                 # for threads
 rw_lock = fasteners.InterProcessReaderWriterLock('path/to/lock.file')  # for processes
 
-with rw_lock.write_locked():
+with rw_lock.write_lock():
     ... # write access
 
-with rw_lock.read_locked():
+with rw_lock.read_lock():
     ... # read access
 
 # or alternatively


### PR DESCRIPTION
Thanks for making fasteners! 😄 

I tried to run code like this (based on what I found in README):
```
import fasteners

rw_lock = fasteners.InterProcessReaderWriterLock("my_tiny.lock")

with rw_lock.write_locked():
    print("writing")

with rw_lock.read_locked():
    print("reading")
```

I got an error like
```
Traceback (most recent call last):
  File "C:/path/to/example.py", line 5, in <module>
    with rw_lock.write_locked():
AttributeError: '_WindowsInterProcessReaderWriterLock' object has no attribute 'write_locked'

Process finished with exit code 1
```

I looked at the fasteners source code and figured that I should use `write_lock` instead of `write_locked`. I hereby propose that the readme should be updated accordingly.