### PR TITLE
Do install top-level "tests" package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     python_requires=">=3.6",
     keywords="locks thread threads interprocess"
              " processes process fasteners",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests"]),
     long_description=long_description,
     long_description_content_type='text/markdown'
 )


### PR DESCRIPTION
8dd5882282abcbe67f7c7613f6381281276057ae has moved tests from inside
the package to top-level.  As a result, `find_packages()` now finds
and installs them as a top-level package.  Pass explicit `exclude=`
to avoid that.