### PR TITLE
Add __version__ and __all__

### DIFF
--- a/fasteners/__init__.py
+++ b/fasteners/__init__.py
@@ -20,13 +20,29 @@
 
 from __future__ import absolute_import
 
-from fasteners.lock import locked  # noqa
-from fasteners.lock import read_locked  # noqa
-from fasteners.lock import ReaderWriterLock  # noqa
-from fasteners.lock import try_lock  # noqa
-from fasteners.lock import write_locked  # noqa
-from fasteners.process_lock import interprocess_locked  # noqa
-from fasteners.process_lock import interprocess_read_locked  # noqa
-from fasteners.process_lock import interprocess_write_locked  # noqa
-from fasteners.process_lock import InterProcessLock  # noqa
-from fasteners.process_lock import InterProcessReaderWriterLock  # noqa
+from fasteners.lock import locked
+from fasteners.lock import read_locked
+from fasteners.lock import ReaderWriterLock
+from fasteners.lock import try_lock
+from fasteners.lock import write_locked
+from fasteners.process_lock import interprocess_locked
+from fasteners.process_lock import interprocess_read_locked
+from fasteners.process_lock import interprocess_write_locked
+from fasteners.process_lock import InterProcessLock
+from fasteners.process_lock import InterProcessReaderWriterLock
+
+from fasteners.version import _VERSION as __version__
+
+__all__ = [
+    '__version__',
+    'locked',
+    'read_locked',
+    'ReaderWriterLock',
+    'try_lock',
+    'write_locked',
+    'interprocess_locked',
+    'interprocess_read_locked',
+    'interprocess_write_locked',
+    'InterProcessLock',
+    'InterProcessReaderWriterLock',
+]


### PR DESCRIPTION
Fixes #77

Adds `__version__` to the fasteners package top-level namespace.

Also, while I was modifying the `__init__.py` file I noticed there were a bunch of `noqa` comments to suppress linter warnings for unused variables. If you define a `__all__` variable linters like flake8 will consider these variables as used (they are defined to be publicly accessible by convention) and therefore not warn about them.


----

As an aside, I used my [mkinit](https://github.com/Erotemic/mkinit) module to autogenerate `__init__` file and then just took the `__all__` variable from that. If you like writing packages that expose submodule attributes in the top-level package, mkinit can help do a lot of the work for you. In this case the result of `mkinit -m fasteners --nomod` is:

```python
# -*- coding: utf-8 -*-

# Copyright (C) 2014 Yahoo! Inc. All Rights Reserved.
#
# All Rights Reserved.
#
#    Licensed under the Apache License, Version 2.0 (the "License"); you may
#    not use this file except in compliance with the License. You may obtain
#    a copy of the License at
#
#         http://www.apache.org/licenses/LICENSE-2.0
#
#    Unless required by applicable law or agreed to in writing, software
#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
#    License for the specific language governing permissions and limitations
#    under the License.

# promote helpers to this module namespace

from __future__ import absolute_import

from fasteners.lock import (ReaderWriterLock, locked, read_locked, try_lock,
                            write_locked,)
from fasteners.process_lock import (InterProcessLock,
                                    InterProcessReaderWriterLock, LOG,
                                    interprocess_locked,
                                    interprocess_read_locked,
                                    interprocess_write_locked,)
from fasteners.version import (version_string,)

__all__ = ['InterProcessLock', 'InterProcessReaderWriterLock', 'LOG',
           'ReaderWriterLock', 'interprocess_locked',
           'interprocess_read_locked', 'interprocess_write_locked', 'locked',
           'read_locked', 'try_lock', 'version_string', 'write_locked']
```

As I said, I only took the `__all__` variable and rearanged it to be consistent with existing package formatting, but I thought I'd mention the package in case others find it useful.