### PR TITLE
Do not depend on the global pointer to LockFileEx (#79)

### DIFF
--- a/fasteners/pywin32/win32file.py
+++ b/fasteners/pywin32/win32file.py
@@ -1,16 +1,17 @@
 from ctypes import POINTER
 from ctypes import pointer
-from ctypes import windll
+from ctypes import WinDLL
 from ctypes.wintypes import BOOL
 from ctypes.wintypes import DWORD
 from ctypes.wintypes import HANDLE
 
 from fasteners.pywin32.pywintypes import OVERLAPPED
 
+kernel32 = WinDLL('kernel32', use_last_error=True)
 _ = pointer
 
 # Refer: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-lockfileex
-LockFileEx = windll.kernel32.LockFileEx
+LockFileEx = kernel32.LockFileEx
 LockFileEx.argtypes = [
     HANDLE,
     DWORD,
@@ -22,7 +23,7 @@ LockFileEx.argtypes = [
 LockFileEx.restype = BOOL
 
 # Refer: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-unlockfile
-UnlockFileEx = windll.kernel32.UnlockFileEx
+UnlockFileEx = kernel32.UnlockFileEx
 UnlockFileEx.argtypes = [
     HANDLE,
     DWORD,
@@ -33,6 +34,6 @@ UnlockFileEx.argtypes = [
 UnlockFileEx.restype = BOOL
 
 # Errors/flags
-GetLastError = windll.kernel32.GetLastError
+GetLastError = kernel32.GetLastError
 
 ERROR_LOCK_VIOLATION = 33

--- a/tests/test_reader_writer_lock.py
+++ b/tests/test_reader_writer_lock.py
@@ -218,3 +218,18 @@ def test_lock_writer_twice(lock_file):
 
     # should release without crashing
     lock.release_write_lock()
+
+
+@pytest.mark.skipif(os.name != 'nt', reason='Only Windows is affected')
+def test_lock_file_ex_global_modification(lock_file):
+    """Some libraries modify the global LockFileEx pointer, and we have to be
+    resistant to that (as well as not modify the global pointer ourselves!)"""
+
+    from ctypes import windll
+    from ctypes.wintypes import DWORD, HANDLE
+
+    windll.kernel32.LockFileEx.argtypes = [HANDLE, DWORD]  # nonsensical signature
+
+    lock = ReaderWriterLock(lock_file)
+    lock.acquire_write_lock(blocking=False)
+    lock.release_write_lock()


### PR DESCRIPTION
Fixes the conflict with django (https://github.com/harlowja/fasteners/issues/79)