### PR TITLE
Link to glossary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ rw_lock.release_write_lock()
 Python standard library provides a lock for threads (both a reentrant one, and a
 non-reentrant one, see below). Fasteners extends this, and provides a lock for
 processes, as well as Reader Writer locks for both threads and processes.
+Definitions of terms used in this overview can be found in the
+[glossary](https://fasteners.readthedocs.io/en/latest/guide/glossary/).
 
 The specifics of the locks are as follows:
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ features are as follows:
 
 ### Thread locks
 
-Fasteners do not provide a simple thread lock, but for the sake of comparison note that the `threading` module
+Fasteners does not provide a simple thread lock, but for the sake of comparison note that the `threading` module
 provides both a reentrant and non-reentrant locks:
 
 | lock | reentrant | mandatory |


### PR DESCRIPTION
I found myself needing to check the docs for this library again, and I had to do some googling to remind myself on some of the terms used in the README.

I went to make a PR that added a few of these links as resources, and to make a long story short, I realized that my old fork of fasteners had a glossary that was removed! More accurately: it was moved to the readthedocs.

While re-adding the entire glossary is likely unnecessary in the README, if it is going to use terms that people might a reference for, it would be good to at least provide a link to that reference. So, I added a single line that just let's the reader know that there is a glossary in the readthedocs.

I also noticed what seems to be a small grammatical error. I suppose you could write `Fasteners do`, but the way I'm reading it "Fasteners" is a proper name of a singular python package, so it should use the singular does instead of the plural do. It's a minor detail, but the modified phrasing feels better to me. I can drop that commit if that's an issue.