### PR TITLE
Use SPDX license identifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ classifiers =
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Utilities
 
-license = ASL 2.0
+license = Apache-2.0
 license_files = LICENSE
 
 [options]


### PR DESCRIPTION
Use SPDX license identifier "Apache-2.0".
That will ease the creation of valid SPDX by tools.