### PR TITLE
Fix typo in error message for releasing lock

### DIFF
--- a/fasteners/process_lock.py
+++ b/fasteners/process_lock.py
@@ -174,7 +174,7 @@ class InterProcessLock:
     def release(self):
         """Release the previously acquired lock."""
         if not self.acquired:
-            raise threading.ThreadError("Unable to release an unaquired lock")
+            raise threading.ThreadError("Unable to release an unacquired lock")
         try:
             self.unlock()
         except Exception as e:


### PR DESCRIPTION
I hate to be _that guy_ opening a one character typo PR but this annoyed me.

fix typo in `fasteners/process_lock.py`